### PR TITLE
fix boot animation issue

### DIFF
--- a/config/bootanimation.mk
+++ b/config/bootanimation.mk
@@ -5,6 +5,10 @@ else ifeq ($(TARGET_BOOT_ANIMATION_RES),1080)
      PRODUCT_COPY_FILES += vendor/lineage/bootanimation/bootanimation-dark_1080.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip     
 else ifeq ($(TARGET_BOOT_ANIMATION_RES),1440)
      PRODUCT_COPY_FILES += vendor/lineage/bootanimation/bootanimation-dark_1440.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1080)
+     PRODUCT_COPY_FILES += vendor/lineage/bootanimation/bootanimation-dark_1080.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1440)
+     PRODUCT_COPY_FILES += vendor/lineage/bootanimation/bootanimation-dark_1440.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
 else
     ifeq ($(TARGET_BOOT_ANIMATION_RES),)
         $(warning "TARGET_BOOT_ANIMATION_RES is undefined, assuming 1080p")


### PR DESCRIPTION
Add a flag for pixels since Pixels bootanimation is better supported on system partition. If doing a dirty flash and bootanimation is not in system, 10X animation is no longer shown and defaults to generic android animation.